### PR TITLE
[WIP] refactor: remove element selectors from blog.

### DIFF
--- a/tmp_src/sass/_blog.scss
+++ b/tmp_src/sass/_blog.scss
@@ -3,7 +3,8 @@
   #BLOG
 \*------------------------------------*/
 
-.blog h1 { text-transform: uppercase; }
+.blog h1,
+.blog .uppercase { text-transform: uppercase; }
 
 .blog h2 { margin-top: rem-calc(40); }
 


### PR DESCRIPTION
The class names won't stay, we're just getting rid of element selectors right now

I'm trying to keep each commit small, review at your leisure. :+1:

Closing this because getting in between the markdown => html conversion is out of scope for getting rid of element selectors.
