### PR TITLE
[RFR] fix(functions): Add a background-position declaration

### DIFF
--- a/tmp_src/sass/_functions.scss
+++ b/tmp_src/sass/_functions.scss
@@ -45,7 +45,10 @@ $rem-base: 16px;
   h4,
   a { color: $color; }
 
-  a { background-image: linear-gradient(to bottom, rgba($color, 1) 75%, rgba($color, .8) 75%); }
+  a {
+    background-image: linear-gradient(to bottom, rgba($color, 1) 75%, rgba($color, .8) 75%);
+    background-position: 0 calc(100% - 0.1em) !important;
+  }
 
   .nav,
   .footer { background-color: $color; }


### PR DESCRIPTION
The underlines on links are weird again, and it seems to be because
the background-positions change depending on the class preceding it.

This fix is temporary, until we can remove element selectors from
the functions themselves, as it's their specificity that is making
us do some weird workarounds.

Fixes #42 and hoodiehq/hood.ie#217.

Before merging, we'll need to run `npm run prod` so that we actually use this new function in CSS.

/cc @verpixelt in case we can get rid of this `!important`
